### PR TITLE
fix: 検索とカテゴリフィルタをAND条件に修正

### DIFF
--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -16,17 +16,12 @@ export async function GET(request: NextRequest) {
     .eq("is_private", false)
     .order("updated_at", { ascending: false }); // メモ一覧を最新順でソート
 
-  // 検索条件とカテゴリフィルタを統合して1つのクエリで処理する
-  if (search || category) {
-    const conditions: string[] = [];
-    if (search) {
-      conditions.push(`title.ilike.%${search}%`);
-      conditions.push(`content.ilike.%${search}%`);
-    }
-    if (category) {
-      conditions.push(`category.eq.${category}`);
-    }
-    query = query.or(conditions.join(","));
+  // 検索条件（OR）とカテゴリフィルタ（AND）を分けて処理する
+  if (search) {
+    query = query.or(`title.ilike.%${search}%,content.ilike.%${search}%`);
+  }
+  if (category) {
+    query = query.eq("category", category);
   }
 
   // ページネーション: Supabaseのrangeはinclusive(両端含む)なので


### PR DESCRIPTION
## 目的
検索ワードとカテゴリフィルタを同時に使うと、関係ないメモまで表示されるバグを修正

## 変更内容
- 検索ワード（タイトル OR 内容）とカテゴリフィルタ（AND）を分離
- `.or()` で全条件を結合していた処理を、検索は `.or()`、カテゴリは `.eq()` に分割

## 原因分析
`src/app/api/memos/route.ts` の29行目で、検索条件とカテゴリ条件を全て `.or()` で結合していたため、
「タイトルに一致 OR 内容に一致 OR カテゴリ一致」となり、カテゴリだけ一致するメモも表示されていた。

## 動作確認
- [x] 検索ワードのみ → 正常に絞り込み
- [x] カテゴリのみ → 正常に絞り込み
- [x] 検索ワード + カテゴリ → AND条件で正しく絞り込み
- [x] `npm test` 全88件パス

## リスク・影響
- 検索API（GET /api/memos）のみの変更で影響範囲は限定的

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)