### PR TITLE
fix: メモ更新時のタイムゾーン二重変換を修正

### DIFF
--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -30,19 +30,13 @@ export async function PUT(
   const body = await request.json();
   const { title, content, category } = body;
 
-  // 日本時間(JST)で統一して保存することで、表示時のタイムゾーン変換を簡素化する
-  // Supabaseのtimestamptz型はISO 8601形式のZ(UTC)表記を正しく解釈する
-  const now = new Date();
-  const JST_OFFSET_MS = 9 * 60 * 60 * 1000; // UTC+9（日本標準時）
-  const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
-
   const { data, error } = await supabase
     .from("memos")
     .update({
       title,
       content,
       category,
-      updated_at: jstNow.toISOString(),
+      updated_at: new Date().toISOString(),
     })
     .eq("id", id)
     .select()


### PR DESCRIPTION
## 目的
メモを編集・保存すると更新日時が未来の時刻になるバグを修正

## 変更内容
- `src/app/api/memos/[id]/route.ts` のPUTハンドラで、手動のJSTオフセット加算を削除
- `new Date().toISOString()` をそのまま渡すように変更

## 原因分析
1. `new Date()` でUTC時刻を取得
2. +9時間（JST_OFFSET_MS）を手動で加算
3. `.toISOString()` で末尾`Z`（UTC表記）の文字列に変換
4. Supabaseの`timestamptz`がこれをUTCとして解釈 → 表示時にさらに+9時間

結果として **+9時間が二重に加算** され、18時間先の時刻が記録されていた。

## 動作確認
- [x] メモ編集後、正しい現在時刻が`updated_at`に記録される
- [x] 一覧ページのソート順が正しい
- [x] `npm test` 全88件パス

## リスク・影響
- PUT /api/memos/[id] のみの変更で影響範囲は限定的

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)