### PR TITLE
fix: メモ作成・編集フォームに公開/非公開の切り替えを追加

### DIFF
--- a/src/app/memo/[id]/edit/page.tsx
+++ b/src/app/memo/[id]/edit/page.tsx
@@ -134,6 +134,7 @@ export default function EditMemoPage({
           initialTitle={memo.title}
           initialContent={memo.content}
           initialCategory={memo.category as import("@/lib/types").Category}
+          initialIsPrivate={memo.is_private}
           onSubmit={handleSubmit}
           isLoading={isSaving}
           submitLabel="更新する"

--- a/src/app/memo/new/page.tsx
+++ b/src/app/memo/new/page.tsx
@@ -30,6 +30,7 @@ export default function NewMemoPage() {
     title: string;
     content: string;
     category: Category;
+    is_private: boolean;
   }) => {
     setIsLoading(true);
     try {

--- a/src/components/MemoForm.tsx
+++ b/src/components/MemoForm.tsx
@@ -8,10 +8,12 @@ type MemoFormProps = {
   initialTitle?: string;
   initialContent?: string;
   initialCategory?: Category;
+  initialIsPrivate?: boolean;
   onSubmit: (data: {
     title: string;
     content: string;
     category: Category;
+    is_private: boolean;
   }) => void;
   isLoading?: boolean;
   submitLabel?: string;
@@ -21,6 +23,7 @@ export default function MemoForm({
   initialTitle = "",
   initialContent = "",
   initialCategory = "general",
+  initialIsPrivate = false,
   onSubmit,
   isLoading = false,
   submitLabel = "保存",
@@ -28,10 +31,11 @@ export default function MemoForm({
   const [title, setTitle] = useState(initialTitle);
   const [content, setContent] = useState(initialContent);
   const [category, setCategory] = useState<Category>(initialCategory);
+  const [isPrivate, setIsPrivate] = useState(initialIsPrivate);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ title, content, category });
+    onSubmit({ title, content, category, is_private: isPrivate });
   };
 
   return (
@@ -107,6 +111,26 @@ export default function MemoForm({
             resize: "vertical",
           }}
         />
+      </div>
+
+      <div>
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            color: "#64748b",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={isPrivate}
+            onChange={(e) => setIsPrivate(e.target.checked)}
+            style={{ width: "1rem", height: "1rem" }}
+          />
+          非公開にする
+        </label>
       </div>
 
       <button


### PR DESCRIPTION
## 目的
メモ作成時に公開/非公開を選択できるUIがなかったため追加

## 変更内容
- `MemoForm` コンポーネントに非公開チェックボックスを追加
- `onSubmit` のデータに `is_private` を含めるように型を拡張
- メモ作成ページ（`memo/new/page.tsx`）で `is_private` をAPIに送信
- メモ編集ページ（`memo/[id]/edit/page.tsx`）で現在の公開状態を初期値として渡す

## 動作確認
- [x] メモ作成画面に「非公開にする」チェックボックスが表示される
- [x] チェックなし → 公開メモとして作成される
- [x] チェックあり → 非公開メモとして作成される
- [x] 編集画面で現在の公開/非公開状態が反映される
- [x] `npm test` 全88件パス

## リスク・影響
- MemoFormの型変更により、既存のonSubmitハンドラに `is_private` が追加される

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)