### PR TITLE
fix: 公開/非公開トグルのロジック反転を修正

### DIFF
--- a/src/app/api/memos/[id]/route.ts
+++ b/src/app/api/memos/[id]/route.ts
@@ -66,7 +66,7 @@ export async function PATCH(
   // isPublic が true → 公開 → is_private を false にする
   const { data, error } = await supabase
     .from("memos")
-    .update({ is_private: isPublic })
+    .update({ is_private: !isPublic })
     .eq("id", id)
     .select()
     .single();


### PR DESCRIPTION
## 目的
メモ詳細ページの公開/非公開トグルが逆に動作するバグを修正

## 変更内容
- `src/app/api/memos/[id]/route.ts` のPATCHハンドラで `is_private: isPublic` → `is_private: !isPublic` に修正

## 原因分析
コメントには「isPublic が true → 公開 → is_private を false にする」と正しく記載されているが、
コード上では `is_private: isPublic` と反転なしで代入していた。

例: 非公開メモ（is_private: true）で「公開にする」を押した場合
- フロント: `isPublic: true` を送信（正しい）
- API: `is_private: true` で更新 → 非公開のまま（バグ）
- 修正後: `is_private: !true = false` → 公開になる（正しい）

## 動作確認
- [x] 非公開メモ → 「公開にする」→ 公開になる
- [x] 公開メモ → 「非公開にする」→ 非公開になる
- [x] `npm test` 全88件パス

## リスク・影響
- PATCH /api/memos/[id] の1行変更のみで影響範囲は限定的

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)