### PR TITLE
fix: ネットワークエラー後にいいねボタンがフリーズする問題を修正

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -48,10 +48,9 @@ export default function LikeButton({
       // ネットワークエラー時は楽観的更新を巻き戻す
       setCount((prev) => prev - 1);
       setIsLiked(false);
+    } finally {
+      setIsLoading(false);
     }
-    // NOTE: isLoadingをリセットしない。
-    // いいねは1メモにつき1回限りなので、成功後にリセットする必要がない。
-    // 成功時はisLiked=trueでボタンがdisabledになるため問題ない。
   };
 
   return (


### PR DESCRIPTION
## 目的
ネットワークエラー発生後にいいねボタンが永久に反応しなくなるバグを修正

## 変更内容
- `src/components/LikeButton.tsx` の `try/catch` に `finally` ブロックを追加し、`setIsLoading(false)` で常にローディング状態をリセット

## 原因分析
1. ボタンクリック時に `isLoading = true` を設定（二重送信防止）
2. ネットワークエラー発生 → catch で `isLiked` と `count` は巻き戻す
3. しかし `isLoading` は `true` のままリセットされない
4. 再クリック時に `if (isLoading) return` で即リターン → ボタンが無反応に

コメントに「成功後はリセット不要」と記載があったが、エラー時のリセットも欠落していた。

## 動作確認
- [x] オフライン → いいね → カウント巻き戻し → オンライン復帰 → 再度いいね可能
- [x] 正常時のいいね動作に影響なし
- [x] `npm test` 全88件パス

## リスク・影響
- LikeButtonコンポーネントのみの変更で影響範囲は限定的

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)