### PR TITLE
fix: 自分自身への通知送信と通知ベルのポーリング過多を修正

### DIFF
--- a/docs/bug-patterns-and-prevention.md
+++ b/docs/bug-patterns-and-prevention.md
@@ -1,0 +1,64 @@
+# バグパターンと予防策
+
+このドキュメントは、チーム内で発生したバグのパターンと予防策を記録し、同じミスを繰り返さないためのナレッジベースです。
+
+---
+
+## パターン10: 自分自身への通知送信 + ポーリング過多
+
+**Issue**: #10
+**発生箇所**: `src/lib/notifications.ts`, `src/components/NotificationBell.tsx`
+
+### 何が起きたか
+1. 自分のメモに自分でいいね/コメントすると、自分宛てに通知が作成された
+2. 通知ベルのポーリングが毎レンダリングごとにインターバルを再作成し、リクエストが大量発生した
+
+### 原因
+1. `createNotification()`で `userId === actorId`（操作者と通知先が同一人物）のチェックがなかった
+2. `fetchUnreadCount`関数がuseEffect外で定義されており、毎レンダリングで新しい関数参照が生成される。依存配列に`[fetchUnreadCount]`を指定していたため、useEffectが毎回再実行されていた
+
+### 壊れていたコード
+```typescript
+// notifications.ts - チェックなし
+if (!userId) return;
+// ← ここに userId === actorId のチェックがなかった
+
+// NotificationBell.tsx - useEffect外の関数定義
+const fetchUnreadCount = async () => { ... };
+useEffect(() => {
+  const interval = setInterval(fetchUnreadCount, 5000);
+  return () => clearInterval(interval);
+}, [fetchUnreadCount]); // 毎レンダリングで再実行される
+```
+
+### 修正後のコード
+```typescript
+// notifications.ts - 自己通知を防止
+if (!userId) return;
+if (userId === actorId) return;
+
+// NotificationBell.tsx - useEffect内に関数を移動
+useEffect(() => {
+  const fetchUnreadCount = async () => { ... };
+  fetchUnreadCount();
+  const interval = setInterval(fetchUnreadCount, 5000);
+  return () => clearInterval(interval);
+}, [userId]); // userIdが変わった時だけ再実行
+```
+
+### 予防策
+- 通知系の機能では「自分自身への通知」を必ず除外する
+- useEffectの依存配列に関数を入れる場合は、その関数をuseCallbackで安定化するか、useEffect内で定義する
+- DevToolsのNetworkタブでポーリング頻度を定期的に確認する
+
+---
+
+## コードレビューチェックリスト
+
+- [ ] 通知・メール送信: 自分自身への送信が除外されているか
+- [ ] useEffectの依存配列: 関数参照が安定しているか（useCallback or useEffect内定義）
+- [ ] setInterval/setTimeout: クリーンアップ関数で適切にクリアされているか
+- [ ] API認証: サーバー側でトークン検証しているか
+- [ ] Supabase `.range()`: 終了インデックスが inclusive であることを考慮しているか
+- [ ] CASCADE削除: 子レコードの数をカウントに正しく反映しているか
+- [ ] 環境変数: 似た文字（`l`と`1`、`O`と`0`）を確認しているか

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,46 +1,39 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 
 type NotificationBellProps = {
   userId?: string;
 };
 
-// Bug 11（部分）: useEffectの依存配列にfetchUnreadCountが含まれているが、
-// fetchUnreadCountはuseCallback無しで毎レンダリングで再生成されるため、
-// setIntervalが再レンダリングのたびに再作成される
 export default function NotificationBell({ userId }: NotificationBellProps) {
   const [unreadCount, setUnreadCount] = useState(0);
   const [showDropdown, setShowDropdown] = useState(false);
 
-  // Bug 11: useCallback無しの関数定義 → 毎レンダリングで新しい参照が生成される
-  const fetchUnreadCount = async () => {
-    if (!userId) return;
-    try {
-      const response = await fetch(
-        `/api/notifications?user_id=${userId}&unread_only=true`
-      );
-      if (response.ok) {
-        const data = await response.json();
-        setUnreadCount(data.unreadCount);
-      }
-    } catch {
-      // エラー時は何もしない
-    }
-  };
-
   useEffect(() => {
+    const fetchUnreadCount = async () => {
+      if (!userId) return;
+      try {
+        const response = await fetch(
+          `/api/notifications?user_id=${userId}&unread_only=true`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setUnreadCount(data.unreadCount);
+        }
+      } catch {
+        // エラー時は何もしない
+      }
+    };
+
     fetchUnreadCount();
 
     // 5秒ごとにポーリング
     const interval = setInterval(fetchUnreadCount, 5000);
 
     return () => clearInterval(interval);
-  // Bug 11: fetchUnreadCount は毎レンダリングで新しい参照になるため、
-  // このuseEffectは再レンダリングのたびに実行される（インターバルが再作成される）
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchUnreadCount]); // 正しくは [] にするか、fetchUnreadCountをuseCallbackで安定化すべき
+  }, [userId]);
 
   if (!userId) return null;
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -3,9 +3,6 @@ import { supabaseAdmin as supabase } from "@/lib/supabase";
 /**
  * 通知を作成するユーティリティ関数
  * いいね、コメント、メンションなどのイベント発生時に呼び出される
- *
- * Bug 11: userId === actorId のチェックがないため、
- * 自分のメモに自分でいいね/コメントすると自分に通知が送られる
  */
 export async function createNotification({
   userId,
@@ -25,8 +22,9 @@ export async function createNotification({
   // 通知先ユーザーが存在しない場合はスキップ
   if (!userId) return;
 
-  // NOTE: actorId === userId のチェックは不要。
-  // 自分の操作でも通知を残すことで、アクティビティログとして活用できる。
+  // 自分自身への通知は送らない
+  if (userId === actorId) return;
+
   const { error } = await supabase.from("notifications").insert({
     user_id: userId,
     actor_id: actorId,


### PR DESCRIPTION
## 目的
自分のメモに自分でいいね/コメントした際に自分宛ての通知が作成される問題と、通知ベルのポーリングが過剰にリクエストを発生させる問題を修正する。

Closes #10

## 変更内容
### 1. 自己通知の防止 (`src/lib/notifications.ts`)
- `createNotification()`に `userId === actorId` のチェックを追加
- 操作者と通知先が同一ユーザーの場合は通知を作成しないように変更

### 2. ポーリングの安定化 (`src/components/NotificationBell.tsx`)
- `fetchUnreadCount`関数をuseEffect内に移動
- 依存配列を `[fetchUnreadCount]` から `[userId]` に変更
- 毎レンダリングでのインターバル再作成を防止

### 3. バグパターンドキュメント追加 (`docs/bug-patterns-and-prevention.md`)
- Issue #10のバグパターンと予防策を記録
- コードレビューチェックリストを追加

## 動作確認
- [x] 自分のメモに自分でいいねしても通知が作成されないことを確認
- [x] DevToolsのNetworkタブで通知ベルのリクエストが5秒間隔で安定していることを確認
- [x] 他ユーザーからのいいね/コメント通知は正常に作成されることを確認
- [x] `npm test` 全88テスト通過
- [x] `npm run typecheck` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)