### PR TITLE
fix: タグ入力の大文字小文字不一致によるエラーを修正

### DIFF
--- a/docs/bug-patterns-and-prevention.md
+++ b/docs/bug-patterns-and-prevention.md
@@ -1,0 +1,60 @@
+# バグパターンと予防策
+
+このドキュメントは、チーム内で発生したバグのパターンと予防策を記録し、同じミスを繰り返さないためのナレッジベースです。
+
+---
+
+## パターン13: 大文字小文字の不一致によるタグ検索・作成エラー
+
+**Issue**: #13
+**発生箇所**: `src/components/TagInput.tsx`, `src/app/api/tags/route.ts`
+
+### 何が起きたか
+1. タグ入力欄に「React」（大文字）と入力しても、DB上の「react」が候補に表示されなかった
+2. Enterキーで新規作成しようとすると、小文字に正規化された「react」がUNIQUE制約に違反し、500エラーが返された
+
+### 原因
+1. オートコンプリートの `.includes()` が大文字小文字を区別して比較していた
+2. タグ作成APIがUNIQUE制約エラー（コード `23505`）を判別せず、一律500エラーとして返していた
+
+### 壊れていたコード
+```typescript
+// TagInput.tsx - case-sensitiveな比較
+tag.name.includes(value.trim())
+
+// tags/route.ts - UNIQUE制約エラーも500で返す
+if (error) {
+  return NextResponse.json({ error: error.message }, { status: 500 });
+}
+```
+
+### 修正後のコード
+```typescript
+// TagInput.tsx - 両方小文字にして比較
+tag.name.toLowerCase().includes(normalizedValue)
+
+// tags/route.ts - UNIQUE制約エラー時は既存タグを返す
+if (error.code === "23505") {
+  const { data: existingTag } = await supabase.from("tags").select("*").eq("name", normalizedName).single();
+  if (existingTag) return NextResponse.json({ tag: existingTag });
+}
+```
+
+### 予防策
+- 文字列比較は大文字小文字を意識する（`.toLowerCase()` で正規化してから比較）
+- DB制約エラーはコード別にハンドリングする（23505=重複、23503=外部キー違反 等）
+- 同じエンティティの「保存時の正規化」と「検索時の正規化」を揃える
+
+---
+
+## コードレビューチェックリスト
+
+- [ ] 文字列比較: 大文字小文字を考慮しているか
+- [ ] DB制約エラー: UNIQUE違反等をコード別にハンドリングしているか
+- [ ] データの保存先と参照先が一致しているか
+- [ ] ユーザー入力のURLがサニタイズされているか
+- [ ] 通知・メール送信: 自分自身への送信が除外されているか
+- [ ] useEffectの依存配列: 関数参照が安定しているか
+- [ ] API認証: サーバー側でトークン検証しているか
+- [ ] 一覧・ランキングAPI: 非公開データのフィルタが入っているか
+- [ ] 日付処理: サーバーサイドでタイムゾーンを明示的に指定しているか

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -16,7 +16,6 @@ export async function GET() {
 }
 
 // POST: 新しいタグを作成
-// Bug 14（部分）: UNIQUE制約エラー(23505)を適切にハンドリングせず一律500を返す
 export async function POST(request: NextRequest) {
   const { name, color } = await request.json();
 
@@ -36,9 +35,19 @@ export async function POST(request: NextRequest) {
     .select()
     .single();
 
-  // Bug 14: UNIQUE制約エラーの場合も一律500を返す
-  // 正しくは 23505 (unique_violation) を判別して既存タグを返すべき
   if (error) {
+    // UNIQUE制約エラーの場合は既存タグを返す
+    if (error.code === "23505") {
+      const { data: existingTag } = await supabase
+        .from("tags")
+        .select("*")
+        .eq("name", normalizedName)
+        .single();
+
+      if (existingTag) {
+        return NextResponse.json({ tag: existingTag });
+      }
+    }
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -10,8 +10,6 @@ type TagInputProps = {
   onTagsChange: (tags: Tag[]) => void;
 };
 
-// Bug 14（部分）: オートコンプリートが大文字小文字を区別して比較する
-// DBには小文字で正規化されたタグが保存されているが、ユーザー入力はそのまま比較
 export default function TagInput({ selectedTags, onTagsChange }: TagInputProps) {
   const [input, setInput] = useState("");
   const [allTags, setAllTags] = useState<Tag[]>([]);
@@ -36,11 +34,10 @@ export default function TagInput({ selectedTags, onTagsChange }: TagInputProps) 
   const handleInputChange = (value: string) => {
     setInput(value);
     if (value.trim()) {
-      // Bug 14: 大文字小文字を区別して比較（.includes は case-sensitive）
-      // 例: "React" と入力しても、DB上の "react" タグは候補に表示されない
+      const normalizedValue = value.trim().toLowerCase();
       const filtered = allTags.filter(
         (tag) =>
-          tag.name.includes(value.trim()) &&
+          tag.name.toLowerCase().includes(normalizedValue) &&
           !selectedTags.some((t) => t.id === tag.id)
       );
       setSuggestions(filtered);


### PR DESCRIPTION
## 目的
タグ入力欄で大文字を含む文字を入力するとオートコンプリートに候補が表示されず、新規作成時にエラーになる問題を修正する。

Closes #13

## 変更内容
### 1. オートコンプリートのcase-insensitive比較 (`src/components/TagInput.tsx`)
- 入力値とタグ名の両方を `.toLowerCase()` で正規化してから `.includes()` で比較
- 「React」と入力しても既存の「react」タグが候補に表示されるように

### 2. UNIQUE制約エラーのハンドリング (`src/app/api/tags/route.ts`)
- エラーコード `23505`（UNIQUE違反）を判別し、既存タグを検索して返すように変更
- 500エラーではなく正常レスポンスとして既存タグを返す

### 3. バグパターンドキュメント追加 (`docs/bug-patterns-and-prevention.md`)

## 動作確認
- [x] 「React」と入力して既存の「react」タグが候補に表示されることを確認
- [x] 「React」でEnterを押して既存の「react」タグが選択されることを確認
- [x] 新規タグ（存在しない名前）が正常に作成されることを確認
- [x] `npm test` 全88テスト通過
- [x] `npm run typecheck` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)