### PR TITLE
fix: 管理者APIの認可チェック欠如を修正（多層防御）

### DIFF
--- a/docs/bug-patterns-and-prevention.md
+++ b/docs/bug-patterns-and-prevention.md
@@ -1,0 +1,68 @@
+# バグパターンと予防策
+
+このドキュメントは、チーム内で発生したバグのパターンと予防策を記録し、同じミスを繰り返さないためのナレッジベースです。
+
+---
+
+## パターン14: ミドルウェアの保護範囲漏れ + API認可チェック欠如
+
+**Issue**: #14
+**発生箇所**: `src/middleware.ts`, `src/app/api/admin/users/route.ts`
+
+### 何が起きたか
+一般ユーザーが `/admin` 画面にはアクセスできないが、`/api/admin/users` にDevToolsから直接リクエストを送ると全ユーザー情報が取得でき、ユーザー削除もできてしまった。
+
+### 原因
+1. ミドルウェアの `matcher` に `/api/admin/:path*` が含まれておらず、APIルートが保護されていなかった
+2. API側に認可チェック（ユーザーのroleがadminか確認）がなかった
+
+### 壊れていたコード
+```typescript
+// middleware.ts - APIパスが含まれていない
+export const config = {
+  matcher: ["/admin/:path*"],  // /api/admin が漏れている
+};
+
+// admin/users/route.ts - 認可チェックなし
+export async function GET() {
+  const { data: profiles } = await supabase.from("profiles").select("*");
+  return NextResponse.json({ users: profiles });
+}
+```
+
+### 修正後のコード
+```typescript
+// middleware.ts - APIパスも追加 + API向けにJSONレスポンス
+export const config = {
+  matcher: ["/admin/:path*", "/api/admin/:path*"],
+};
+
+// admin/users/route.ts - トークンからroleを検証
+async function verifyAdmin(request) {
+  const token = request.headers.get("Authorization")?.replace("Bearer ", "");
+  const { data: { user } } = await supabase.auth.getUser(token);
+  const { data: profile } = await supabase.from("profiles").select("role").eq("id", user.id).single();
+  if (profile?.role !== "admin") return { authorized: false };
+  return { authorized: true };
+}
+```
+
+### 予防策
+- **多層防御**: ミドルウェアとAPI両方で認可チェックを行う
+- ミドルウェアのmatcherは画面パスとAPIパスの両方を含める
+- APIがJSONを返す場合、エラー時もリダイレクトではなくJSONで返す
+- 管理者APIは必ずトークンからユーザーのroleを検証する
+
+---
+
+## コードレビューチェックリスト
+
+- [ ] 管理者API: ミドルウェアとAPI両方で認可チェックしているか
+- [ ] ミドルウェアmatcher: 画面パスとAPIパスの両方が含まれているか
+- [ ] 文字列比較: 大文字小文字を考慮しているか
+- [ ] DB制約エラー: UNIQUE違反等をコード別にハンドリングしているか
+- [ ] データの保存先と参照先が一致しているか
+- [ ] ユーザー入力のURLがサニタイズされているか
+- [ ] API認証: サーバー側でトークン検証しているか
+- [ ] 一覧・ランキングAPI: 非公開データのフィルタが入っているか
+- [ ] 日付処理: サーバーサイドでタイムゾーンを明示的に指定しているか

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,12 +15,19 @@ export default function AdminPage() {
 
   useEffect(() => {
     const init = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        setUserName(user.user_metadata?.display_name);
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        router.push("/login");
+        return;
       }
+      setUserName(user.user_metadata?.display_name);
 
-      const response = await fetch("/api/admin/users");
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
+
+      const response = await fetch("/api/admin/users", {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
       if (response.ok) {
         const data = await response.json();
         setUsers(data.users || []);
@@ -28,14 +35,20 @@ export default function AdminPage() {
       setIsLoading(false);
     };
     init();
-  }, []);
+  }, [router]);
 
   const handleDeleteUser = async (userId: string) => {
     if (!confirm("このユーザーを削除しますか？この操作は取り消せません。")) return;
 
+    const { data: { session } } = await supabase.auth.getSession();
+    const token = session?.access_token;
+
     const response = await fetch("/api/admin/users", {
       method: "DELETE",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify({ user_id: userId }),
     });
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,10 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin as supabase } from "@/lib/supabase";
 
+// 管理者権限を確認するヘルパー関数
+async function verifyAdmin(request: NextRequest): Promise<{ authorized: boolean; response?: NextResponse }> {
+  const token = request.headers.get("Authorization")?.replace("Bearer ", "");
+  if (!token) {
+    return { authorized: false, response: NextResponse.json({ error: "認証が必要です" }, { status: 401 }) };
+  }
+
+  const { data: { user } } = await supabase.auth.getUser(token);
+  if (!user) {
+    return { authorized: false, response: NextResponse.json({ error: "認証が必要です" }, { status: 401 }) };
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile || profile.role !== "admin") {
+    return { authorized: false, response: NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 }) };
+  }
+
+  return { authorized: true };
+}
+
 // GET: ユーザー一覧を取得（管理者用）
-// Bug 15a: middleware.tsの matcher に /api/admin が含まれていないため、
-// 認可チェックなしでアクセス可能
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const { authorized, response } = await verifyAdmin(request);
+  if (!authorized) return response!;
+
   const { data: profiles, error } = await supabase
     .from("profiles")
     .select("*")
@@ -18,9 +44,10 @@ export async function GET() {
 }
 
 // DELETE: ユーザーを削除（管理者用）
-// Bug 15a: middleware.tsの matcher に /api/admin が含まれていないため、
-// 認可チェックなしでアクセス可能
 export async function DELETE(request: NextRequest) {
+  const { authorized, response } = await verifyAdmin(request);
+  if (!authorized) return response!;
+
   const { user_id } = await request.json();
 
   if (!user_id) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,12 @@ export async function middleware(request: NextRequest) {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
+    const isApiRequest = request.nextUrl.pathname.startsWith("/api/");
+
     if (!supabaseUrl || !supabaseAnonKey) {
+      if (isApiRequest) {
+        return NextResponse.json({ error: "サーバー設定エラー" }, { status: 500 });
+      }
       return NextResponse.redirect(new URL("/login", request.url));
     }
 
@@ -19,6 +24,9 @@ export async function middleware(request: NextRequest) {
     const token = request.cookies.get("sb-access-token")?.value;
 
     if (!token) {
+      if (isApiRequest) {
+        return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+      }
       return NextResponse.redirect(new URL("/login", request.url));
     }
 
@@ -32,6 +40,9 @@ export async function middleware(request: NextRequest) {
       } = await supabase.auth.getUser(token);
 
       if (!user) {
+        if (isApiRequest) {
+          return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+        }
         return NextResponse.redirect(new URL("/login", request.url));
       }
 
@@ -43,14 +54,13 @@ export async function middleware(request: NextRequest) {
         .single();
 
       if (!profile || profile.role !== "admin") {
-        // API リクエストの場合はJSONで403を返す
-        if (request.nextUrl.pathname.startsWith("/api/")) {
+        if (isApiRequest) {
           return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
         }
         return NextResponse.redirect(new URL("/", request.url));
       }
     } catch {
-      if (request.nextUrl.pathname.startsWith("/api/")) {
+      if (isApiRequest) {
         return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
       }
       return NextResponse.redirect(new URL("/login", request.url));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,13 +4,10 @@ import { createClient } from "@supabase/supabase-js";
 
 /**
  * 管理者パネルへのアクセスを制限するミドルウェア
- *
- * Bug 15a: matcher が "/admin/:path*" のみで、"/api/admin/:path*" を含んでいない
- * そのため、管理者画面にはアクセスできないが、管理者APIには誰でもアクセスできる
  */
 export async function middleware(request: NextRequest) {
-  // 管理者パスへのアクセスをチェック
-  if (request.nextUrl.pathname.startsWith("/admin")) {
+  // 管理者パス（画面・API両方）へのアクセスをチェック
+  if (request.nextUrl.pathname.startsWith("/admin") || request.nextUrl.pathname.startsWith("/api/admin")) {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -46,9 +43,16 @@ export async function middleware(request: NextRequest) {
         .single();
 
       if (!profile || profile.role !== "admin") {
+        // API リクエストの場合はJSONで403を返す
+        if (request.nextUrl.pathname.startsWith("/api/")) {
+          return NextResponse.json({ error: "管理者権限が必要です" }, { status: 403 });
+        }
         return NextResponse.redirect(new URL("/", request.url));
       }
     } catch {
+      if (request.nextUrl.pathname.startsWith("/api/")) {
+        return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+      }
       return NextResponse.redirect(new URL("/login", request.url));
     }
   }
@@ -56,7 +60,6 @@ export async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
-// Bug 15a: "/api/admin/:path*" が含まれていないため、APIルートは保護されない
 export const config = {
-  matcher: ["/admin/:path*"],
+  matcher: ["/admin/:path*", "/api/admin/:path*"],
 };


### PR DESCRIPTION
## 目的
一般ユーザーがDevToolsから管理者API（`/api/admin/users`）に直接リクエストを送るとユーザー情報の取得・削除ができてしまうセキュリティ問題を修正する。

Closes #14

## 変更内容
### 1. ミドルウェアの保護範囲拡大 (`src/middleware.ts`)
- matcherに `/api/admin/:path*` を追加し、APIルートもミドルウェアで保護
- API向けリクエスト時はリダイレクトではなくJSON形式で401/403を返す

### 2. API側の認可チェック追加 (`src/app/api/admin/users/route.ts`)
- `verifyAdmin()` ヘルパー関数を追加（トークンからユーザー取得 → role確認）
- GET・DELETE両方で認可チェックを実施（多層防御）

### 3. 管理者画面のトークン送信 (`src/app/admin/page.tsx`)
- fetch呼び出しにAuthorizationヘッダーを追加
- GET・DELETE両方でトークンを送信

### 4. バグパターンドキュメント追加 (`docs/bug-patterns-and-prevention.md`)

## 動作確認
- [x] 一般ユーザーで `fetch('/api/admin/users')` を実行すると401/403が返ることを確認
- [x] 管理者ユーザーで `/admin` 画面が正常に表示されることを確認
- [x] `npm test` 全88テスト通過
- [x] `npm run typecheck` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)